### PR TITLE
Fix calloc argument order

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -1,11 +1,11 @@
 #include "game.h"
 
 static Map create_map() {
-  Map map = calloc(sizeof(int **), N_TILE);
+  Map map = calloc(N_TILE, sizeof(int *));
   if (!map)
     exit(1);
   for (int y = 0; y != N_TILE; y++) {
-    map[y] = calloc(sizeof(int) * N_TILE, N_TILE);
+    map[y] = calloc(N_TILE, sizeof(int));
     if (!map[y])
       exit(1);
   }
@@ -32,7 +32,7 @@ static int get_nei(Map map, int y, int x) {
 }
 
 Game *create_game(SDL_Renderer *renderer) {
-  Game *g = calloc(sizeof(Game), 1);
+  Game *g = calloc(1, sizeof(Game));
   if (!g)
     exit(1);
   g->renderer = renderer;
@@ -85,9 +85,9 @@ void random_map(Game *g) {
 void rotate_pattern(Game *g) {
   if (!g->to_place)
     return;
-  int **map = calloc(sizeof(int *), g->to_place_length);
+  int **map = calloc(g->to_place_length, sizeof(int *));
   for (int y = 0; y != g->to_place_length; y++)
-    map[y] = calloc(sizeof(int), g->to_place_height);
+    map[y] = calloc(g->to_place_height, sizeof(int));
   for (int y = 0; y != g->to_place_height; y++)
     for (int x = 0; x != g->to_place_length; x++)
       map[x][g->to_place_height - y - 1] = g->to_place[y][x];

--- a/src/menu.c
+++ b/src/menu.c
@@ -80,7 +80,7 @@ static void display_patterns_win(Menu *m) {
 }
 
 Menu *init_win(Storage **storage) {
-  Menu *m = calloc(sizeof(Menu), 1);
+  Menu *m = calloc(1, sizeof(Menu));
   m->mainWin = initscr();
   m->menuWin = subwin(m->mainWin, 5, 120, 50, 40);
   m->patternsWin = subwin(m->mainWin, 46, 201, 2, 5);
@@ -147,9 +147,9 @@ static void choose_pattern(Game *g, Menu *m) {
     for (int y = 0; y != g->to_place_height; y++)
       free(g->to_place[y]);
   free(g->to_place);
-  g->to_place = calloc(sizeof(int *), pat->height);
+  g->to_place = calloc(pat->height, sizeof(int *));
   for (int y = 0; y != pat->height; y++) {
-    g->to_place[y] = calloc(sizeof(int), pat->length);
+    g->to_place[y] = calloc(pat->length, sizeof(int));
     memcpy(g->to_place[y], pat->map[y], sizeof(int) * pat->length);
   }
   g->to_place_height = pat->height;

--- a/src/pattern.c
+++ b/src/pattern.c
@@ -21,9 +21,9 @@ static enum Type get_type(const char *s) {
 static void get_map(Pattern *pat, FILE *f) {
   char *buff = NULL;
   size_t ms = 0;
-  pat->map = calloc(sizeof(int *), pat->height);
+  pat->map = calloc(pat->height, sizeof(int *));
   for (int y = 0; y != pat->height; y++) {
-    pat->map[y] = calloc(sizeof(int), pat->length);
+    pat->map[y] = calloc(pat->length, sizeof(int));
     getline(&buff, &ms, f);
     for (int x = 0; x != pat->length; x++)
       pat->map[y][x] = buff[x] == '1';
@@ -54,7 +54,7 @@ static Pattern *parse_file(FILE *f) {
 }
 
 static Pattern *get_pattern(const char *fname) {
-  char *f_name = calloc(sizeof(char), (strlen(fname) + 12));
+  char *f_name = calloc(strlen(fname) + 12, sizeof(char));
   strcat(f_name, "patterns/");
   strcat(f_name, fname);
   FILE *f = fopen(f_name, "r");
@@ -63,9 +63,9 @@ static Pattern *get_pattern(const char *fname) {
 }
 
 Storage **load_patterns() {
-  Storage **storage = calloc(sizeof(Storage *), NB_PATTERNS_TYPE);
+  Storage **storage = calloc(NB_PATTERNS_TYPE, sizeof(Storage *));
   for (int i = 0; i != NB_PATTERNS_TYPE; i++) {
-    storage[i] = calloc(sizeof(Storage), 1);
+    storage[i] = calloc(1, sizeof(Storage));
     storage[i]->type = i;
   }
   DIR *d;


### PR DESCRIPTION
## Summary
- reduce memory usage by using correct calloc parameter order

## Testing
- `cmake ..` *(fails: Package 'SDL2_ttf' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e7fc5ff48333a057b8cfe1e3ccfe